### PR TITLE
feat: command-palette: Toggle

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,14 @@ export default class QueuePlugin extends Plugin {
             // and than passed to the mediator
             this.queueBar.toggle()
         });
+        
+  		this.addCommand({
+			id: 'queueBar-toggle',
+			name: 'Toggle',
+			callback: () => {
+				this.queueBar.toggle()
+			},
+		});
     }
 
     unload() {


### PR DESCRIPTION
Tiny PR: Added `Queue: Toggle` command to the Obsidian **Command Palette**.

This makes the queue bar accessible not only via the ribbon icon, but also via the command palette search. As a bonus, users can now assign **a custom hotkey** to toggle the queue bar quickly

<img width="741" height="391" alt="the-queue-command-palette-toggle" src="https://github.com/user-attachments/assets/dc8e9038-1493-4c24-9335-ce768b896dd1" />